### PR TITLE
added displayName field to User

### DIFF
--- a/src/main/java/cat/udl/eps/softarch/domain/User.java
+++ b/src/main/java/cat/udl/eps/softarch/domain/User.java
@@ -22,6 +22,7 @@ public class User implements UserDetails {
     @Id
     private String username;
     private String uri;
+    private String displayName;
     @NotBlank(message = "Name cannot be blank")
     private String name;
     private String lastname;
@@ -51,6 +52,11 @@ public class User implements UserDetails {
 
     public void setName (String name){
         this.name=name;
+
+        // Display name defaults to user name.
+        if (this.getDisplayName() == null || this.getDisplayName().isEmpty()) {
+            this.setDisplayName(this.getName());
+        }
     }
 
     public String getName(){
@@ -121,5 +127,13 @@ public class User implements UserDetails {
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return AuthorityUtils.commaSeparatedStringToAuthorityList("ROLE_USER");
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
     }
 }

--- a/src/main/java/cat/udl/eps/softarch/handler/UserHandler.java
+++ b/src/main/java/cat/udl/eps/softarch/handler/UserHandler.java
@@ -32,5 +32,8 @@ public class UserHandler {
     public void handleUserPreSave(User user) {
         if (user.getPassword() != null)
             user.setPassword(bCryptPasswordEncoder.encode(user.getPassword()));
+
+        // For some reason, PreSave doesn't call setters.
+        user.setName(user.getName());
     }
 }

--- a/src/test/java/cat/udl/eps/softarch/steps/UserStepDefs.java
+++ b/src/test/java/cat/udl/eps/softarch/steps/UserStepDefs.java
@@ -112,4 +112,14 @@ public class UserStepDefs extends AbstractStepDefs {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name", is(username)));
     }
+
+    @Then("^There is a registered user with display name \"([^\"]*)\"$")
+    public void thereIsARegisteredUserWithDisplayName(String displayName) throws Throwable {
+        result = mockMvc.perform(
+                get("/users/{username}", displayName)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.displayName", is(displayName)));
+    }
 }

--- a/src/test/resources/features/CreateUser.feature
+++ b/src/test/resources/features/CreateUser.feature
@@ -13,4 +13,5 @@ Feature: User Management
     And I can login with username "johnsmith" and password "password"
     When I update username "johnsmith" password to "PassWord"
     Then I can login with username "johnsmith" and password "PassWord"
+    And There is a registered user with display name "johnsmith"
     And I cannot login with username "johnsmith" and password "password"


### PR DESCRIPTION
Facebook login identifiers (which auth0 uses) can be quite long, so they might not be appropriate to show on the web as friendly user names.
`Name` and `last name` can be quite personal.

A `display name` might be somewhere in the middle, just like stackoverflow does, which will solely serve as a friendly name to see while browsing the site (it doesn't even need to be unique).